### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       digests: ${{ steps.hash.outputs.digests }}


### PR DESCRIPTION
Potential fix for [https://github.com/andreaslam/ZanLing-TrueZero/security/code-scanning/2](https://github.com/andreaslam/ZanLing-TrueZero/security/code-scanning/2)

In general, the problem is fixed by explicitly defining a `permissions` block either at the workflow root (to apply to all jobs that don’t override it) or at the individual job level, and setting it to the minimal privileges needed. For this workflow, the `build` job only needs to read repository contents to perform `actions/checkout@v3` and then work on local files; it does not push commits, create releases, or modify issues. Therefore, it should have `contents: read` at minimum, and no other write permissions. The `provenance` job already has an explicit, more permissive block tailored to its needs.

The single best fix without changing existing functionality is to add a `permissions` block directly under the `build` job (at the same indentation as `runs-on:`) specifying `contents: read`. This keeps the behavior of `actions/checkout@v3` while preventing unintended write access. No new imports or dependencies are needed; this is a pure YAML configuration change in `.github/workflows/generator-generic-ossf-slsa3-publish.yml`, in the region around lines 19–23 where the `build` job is defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
