### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -452,7 +452,7 @@ class DataReceiver(QObject):
     def run_gui_testing(self, login_screen, experiment_tracker):
         password = "bar"
         print(
-            f"[Note]: this is the demo version of TrueScheduler. use '{password}' to access the rest of the GUI."
+            "[Note]: this is the demo version of TrueScheduler. Use the demo password to access the rest of the GUI."
         )
         print("debugging prints and logging enabled.")
         while True:


### PR DESCRIPTION
Potential fix for [https://github.com/andreaslam/ZanLing-TrueZero/security/code-scanning/1](https://github.com/andreaslam/ZanLing-TrueZero/security/code-scanning/1)

In general, to fix clear-text logging of sensitive data, you should avoid including the actual secret value in any log or console output. Instead, either omit it completely, log only non-sensitive metadata (e.g., “password provided” without the value), or use a placeholder such as `"***"` if you must indicate its presence.

For this specific code, the minimal, behavior-preserving fix is to keep the informational message that this is a demo version but remove the interpolation of the `password` variable so that the actual password is no longer printed. Since the rest of `run_gui_testing` already uses the `password` variable internally to validate input, we do not change that logic. Only line 455 needs to be modified to no longer reveal `password`. No new imports or helper functions are required; we only adjust the string literal in the `print` call in `run_gui_testing` in `gui.py`.

Concretely:
- In `gui.py`, in `run_gui_testing`, replace the `print` on line 455 with a version that does not include `{password}`. For example: `print("[Note]: this is the demo version of TrueScheduler. Use the demo password to access the rest of the GUI.")`.
- Leave the rest of the function, including the `password = "bar"` assignment and subsequent checks, unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
